### PR TITLE
Set "User-Agent" in Node only

### DIFF
--- a/index.mjs
+++ b/index.mjs
@@ -191,7 +191,11 @@ export default class WooCommerceRestApi {
       Accept: "application/json"
     };
     // only set "User-Agent" in node environment
-    if (typeof window === "undefined") {
+    // the checking method is identical to upstream axios
+    if (
+      typeof process !== "undefined" &&
+      Object.prototype.toString.call(process) === "[object process]"
+    ) {
       headers["User-Agent"] =
         "WooCommerce REST API - JS Client/" + this.classVersion;
     }

--- a/index.mjs
+++ b/index.mjs
@@ -191,11 +191,7 @@ export default class WooCommerceRestApi {
       Accept: "application/json"
     };
     // only set "User-Agent" in node environment
-    // the checking method is identical to upstream axios
-    if (
-      typeof process !== "undefined" &&
-      Object.prototype.toString.call(process) === "[object process]"
-    ) {
+    if (typeof window === "undefined") {
       headers["User-Agent"] =
         "WooCommerce REST API - JS Client/" + this.classVersion;
     }

--- a/index.mjs
+++ b/index.mjs
@@ -187,16 +187,26 @@ export default class WooCommerceRestApi {
   _request(method, endpoint, data, params = {}) {
     const url = this._getUrl(endpoint, params);
 
+    const headers = {
+      Accept: "application/json"
+    };
+    // only set "User-Agent" in node environment
+    // the checking method is identical to upstream axios
+    if (
+      typeof process !== "undefined" &&
+      Object.prototype.toString.call(process) === "[object process]"
+    ) {
+      headers["User-Agent"] =
+        "WooCommerce REST API - JS Client/" + this.classVersion;
+    }
+
     let options = {
       url: url,
       method: method,
       responseEncoding: this.encoding,
       timeout: this.timeout,
       responseType: "json",
-      headers: {
-        "User-Agent": "WooCommerce REST API - JS Client/" + this.classVersion,
-        Accept: "application/json"
-      }
+      headers
     };
 
     if (this.isHttps) {


### PR DESCRIPTION
Resolve #34 

"User-Agent" should only set in the NodeJS environment.

Although, the specification [[1]](https://fetch.spec.whatwg.org/#terminology-headers) [[2]](https://developer.mozilla.org/en-US/docs/Web/API/XMLHttpRequest/setRequestHeader) allow the modification of "User-Agent". Some of the broswer (e.g. Chrome, Safari) will block this action as it is not secure.