### PR TITLE
Changed README to say 'ECMAScript modules' not 'Embedded System Module'

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # WooCommerce REST API - JavaScript Library
 
-New JavaScript library for WooCommerce REST API, supports CommonJS (CJS) and Embedded System Module (ESM).
+New JavaScript library for WooCommerce REST API, supports CommonJS (CJS) and ECMAScript Modules (ESM).
 
 Requests are made with [Axios library](https://github.com/axios/axios) with [support to promises](https://github.com/axios/axios#promises).
 


### PR DESCRIPTION
This fixes the README file's wrong name for ESM.