### PR TITLE
Set parse URL independent of browser window

### DIFF
--- a/index.mjs
+++ b/index.mjs
@@ -95,7 +95,7 @@ export default class WooCommerceRestApi {
       return url;
     }
 
-    const query = new Url(url, null, true).query;
+    const query = new Url(url, {}, true).query;
     const values = [];
 
     let queryString = "";
@@ -140,7 +140,7 @@ export default class WooCommerceRestApi {
 
     // Include port.
     if (this.port !== "") {
-      const hostname = new Url(url).hostname;
+      const hostname = new Url(url, {}).hostname;
 
       url = url.replace(hostname, hostname + ":" + this.port);
     }


### PR DESCRIPTION
Based on parse-url plugin: 

Note that when url-parse is used in a browser environment, it will default to using the browser's current window location as the base URL when parsing all inputs. To parse an input independently of the browser's current URL (e.g. for functionality parity with the library in a Node environment), pass an empty location object as the second parameter:

```
var parse = require('url-parse');
parse('hostname', {});
```

when i tried to use the plugin with gatsby SSR failed due to url not being string as it could not extract window info causing `Cannot read property 'split' of null` to crash whole SSR. 

passing second argument as `{}` solved the issue in SSR.