### PR TITLE
Remove Unnecessary JSON.stringify

### DIFF
--- a/index.mjs
+++ b/index.mjs
@@ -232,7 +232,6 @@ export default class WooCommerceRestApi {
 
     if (data) {
       options.headers["Content-Type"] = "application/json;charset=utf-8";
-      options.data = JSON.stringify(data);
     }
 
     // Allow set and override Axios options.


### PR DESCRIPTION
Axios "automagically" stringfies the post body, there's no need to pre-stringify.

Pre-stringifying can result in unexpected behavior when you're passing in JSON content that includes quotes, such as `{ name: "My name is \"Mike\"" }`