### PR TITLE
Remove unnecessary instance check in the constructor

### DIFF
--- a/index.mjs
+++ b/index.mjs
@@ -17,10 +17,6 @@ export default class WooCommerceRestApi {
    * @param {Object} opt
    */
   constructor(opt) {
-    if (!(this instanceof WooCommerceRestApi)) {
-      return new WooCommerceRestApi(opt);
-    }
-
     opt = opt || {};
 
     if (!opt.url) {


### PR DESCRIPTION
Refactored the WooCommerceRestApi class constructor to remove the unnecessary instance check. In modern JavaScript classes, the new keyword is required to create an instance of a class.