### PR TITLE
[SIRT] Updating axios version to 1.6.8

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "index.d.ts"
   ],
   "dependencies": {
-    "axios": "^1.6.0",
+    "axios": "^1.6.8",
     "create-hmac": "^1.1.7",
     "oauth-1.0a": "^2.2.6",
     "url-parse": "^1.4.7"


### PR DESCRIPTION
Address https://cwe.mitre.org/data/definitions/200.html
Address https://cwe.mitre.org/data/definitions/212.html

To address https://github.com/woocommerce/woocommerce-gateway-stripe/security/dependabot/20 in the Stripe extension repository, we need to update `axios` to bump `follow-redirects` to at least `1.15.6` (`1.15.9` in practice).

- axios `1.6.8` https://github.com/axios/axios/releases/tag/v1.6.8